### PR TITLE
Remove unnecessary suspend keyword from function returning a Flow

### DIFF
--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/DatabaseHelper.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/DatabaseHelper.kt
@@ -34,7 +34,7 @@ class DatabaseHelper(
         }
     }
 
-    suspend fun selectById(id: Long): Flow<List<Breed>> =
+    fun selectById(id: Long): Flow<List<Breed>> =
         dbRef.tableQueries
             .selectById(id)
             .asFlow()


### PR DESCRIPTION
Suspend functions should return when all of their work is done, returning a Flow shouldn't require the function to be suspending.
More context here: https://rules.sonarsource.com/kotlin/RSPEC-6309

Is there some other reason in particular why this was marked as suspend? I've built the project fine locally with this change.